### PR TITLE
fix an error of randomgenerator at bls.init()

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 const nop = require('nop')
 const Buffer = require('safe-buffer').Buffer
 const mod = require('./build/bls_lib.js')
+const crypto = require('crypto')
+crypto.getRandomValues = crypto.randomFillSync
 
 let init = false
 let initCb = nop


### PR DESCRIPTION
The following operations cause an error.
```
npm install bls-lib
>node
>bls = require('bls-lib')
>bls.init()
randomgenerator:read:32
-1
```
